### PR TITLE
break sentences and break after Break_Around_Elements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "prettier-plugin-pretext",
-    "version": "1.0.0",
+    "version": "1.0.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "prettier-plugin-pretext",
-            "version": "1.0.0",
+            "version": "1.0.3",
             "license": "MIT",
             "dependencies": {
                 "@xml-tools/parser": "^1.0.11",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -21,8 +21,9 @@ const plugin: Plugin = {
     options: {},
     defaultOptions: {
         printWidth: 80,
-        tabWidth: 4,
-        useTabs: true,
+        tabWidth: 2,
+        useTabs: false,
+        singleAttributePerLine: false,
     },
 };
 

--- a/src/pretext/special-nodes.ts
+++ b/src/pretext/special-nodes.ts
@@ -26,12 +26,14 @@ export const PAR_ELEMENTS = new Set([
     "idx",
     "h",
     "description",
+    "shortdescription",
     "caption",
     "cell",
     "q",
-    "em",
     "title",
     "pubtitle",
+    "fn",
+    "me",
 ]);
 /**
  * Elements which should be on their own line even in paragraph mode.
@@ -40,7 +42,6 @@ export const BREAK_AROUND_ELEMENTS = new Set([
     "ol",
     "ul",
     "dl",
-    "p",
     "q",
     "title",
     "pubtitle",

--- a/src/print-children.ts
+++ b/src/print-children.ts
@@ -7,7 +7,8 @@ const { fill, group, hardline, indent, join, line, literalline, softline } =
 
 /**
  * Prints the children of `path` but trims whitespace from the start/end and collapses
- * contiguous whitespace into a single char.
+ * contiguous whitespace into a single char.  Inserts `line` between words, and `hardline`
+ * after sentence-ending punctuation (.!?).
  */
 export function printChildrenWhenWhitespaceDoesNotMatter(
     path: Path<AnyNode>,
@@ -40,8 +41,11 @@ export function printChildrenWhenWhitespaceDoesNotMatter(
                     const trailingWhitespace = rawText.match(/\s*$/)![0].length;
                     const content = rawText.trim();
                     const printed = fill(
-                        content.split(/(\s+)/g).map((value) => {
-                            if (value.match(/\s+/)) {
+                        content.split(/(\s+|[.!?]\s+)/g).map((value) => {
+                            if (value.match(/[.!?]\s+/)) {
+                                // This will put a linebreak after any sentence-ending punctuation in chardata.
+                                return [value.trim(), hardline];
+                            } else if (value.match(/\s+/)) {
                                 return line;
                             }
                             return value;

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -386,11 +386,13 @@ const printer: Printer = {
                     );
 
                     if (fragments.length === 0) {
-                        return group([...parts, space, "/>"]);
+
+                        return group([...parts, "/>"]);
                     }
 
                     // If the only content of this tag is chardata, then use a softline so
                     // that we won't necessarily break (to allow <foo>bar</foo>).
+                    // Actually, don't add any new lines here:
                     if (
                         fragments.length === 1 &&
                         (content[0].children.chardata || []).filter(
@@ -399,8 +401,7 @@ const printer: Printer = {
                     ) {
                         return group([
                             openTag,
-                            indent([softline, fragments[0].printed]),
-                            softline,
+                            [fragments[0].printed],
                             closeTag,
                         ]);
                     }
@@ -461,7 +462,7 @@ const printer: Printer = {
                             } else {
                                 docsAndFragsWithLines.push(hardline);
                             }
-                            docsAndFragsWithLines.push(item);
+                            docsAndFragsWithLines.push(item, hardline);
                             prevItem = item;
                             continue;
                         }
@@ -534,7 +535,13 @@ const printer: Printer = {
                 }
 
                 const space = opts.xmlSelfClosingSpace ? line : softline;
-                return group([...parts, space, SPECIAL_CLOSE[0].image]);
+                // Added hardline to separate the prolog from the content
+                return [group([...parts, space, SPECIAL_CLOSE[0].image]), hardline];
+            }
+
+            default: {
+                console.log("default", node);
+                throw new Error("Unknown node type: " + (node as any).name);
             }
         }
     },

--- a/test/__snapshots__/format.test.ts.snap
+++ b/test/__snapshots__/format.test.ts.snap
@@ -2,149 +2,154 @@
 
 exports[`basic pretext source 1`] = `
 "<section>
-	<cline>abc(foo)</cline>
-	<li xml:id=\\"list-two-two-two-three\\">
-		<title>Title on xref'ed list item</title>
-		<p>Level 4, third.</p>
-	</li>
-	<subsection>
-		<abstract>
-			<p>
-				This is a sample of many of the things you can do with <pretext />.
-				Sometimes the math makes sense, sometimes it seems to be written
-				in the first person, sort of like this Abstract.
-			</p>
-		</abstract>
-	</subsection>
-	<macros>
-		\\\\newcommand{\\\\definiteintegral}[4]{\\\\int_{#1}^{#2}\\\\,#3\\\\,d#4} % this comment will be stripped
-		\\\\newcommand{\\\\myequation}[2]{#1\\\\amp =#2} % testing alignment override
-		% comments anywhere get stripped, with or without faux % comment \\\\% characters
-		\\\\newcommand{\\\\indefiniteintegral}[2]{\\\\int#1\\\\,d#2}
-		\\\\newcommand{\\\\testingescapedpercent}{ \\\\% } % just testing
-	</macros>
-	<macros>\\\\newcommand{\\\\definiteintegral}[4]{\\\\int_{#1}   }</macros>
+  <cline>abc(foo)</cline>
+  <li xml:id=\\"list-two-two-two-three\\">
+    <title>Title on xref'ed list item</title>
+     <p>Level 4, third.</p>
+  </li>
+  <subsection>
+    <abstract>
+      <p>
+        This is a sample of many of the things you can do with <pretext />.
+        Sometimes the math makes sense, sometimes it seems to be written in the
+        first person, sort of like this Abstract.
+      </p>
+    </abstract>
+  </subsection>
+  <macros>
+    \\\\newcommand{\\\\definiteintegral}[4]{\\\\int_{#1}^{#2}\\\\,#3\\\\,d#4} % this comment will be stripped
+    \\\\newcommand{\\\\myequation}[2]{#1\\\\amp =#2} % testing alignment override
+    % comments anywhere get stripped, with or without faux % comment \\\\% characters
+    \\\\newcommand{\\\\indefiniteintegral}[2]{\\\\int#1\\\\,d#2}
+    \\\\newcommand{\\\\testingescapedpercent}{ \\\\% } % just testing
+  </macros>
+  <macros>\\\\newcommand{\\\\definiteintegral}[4]{\\\\int_{#1}   }</macros>
 </section>
 "
 `;
 
 exports[`basic pretext source 2 1`] = `
 "<section>
-	<p>A video is a <br /> natural way to</p>
-	<p>
-		A video is a natural <br /> way to enhance a document when rendered in
-		an electronic format, such as HTML web pages. It might be additional
-		information that is hard to communicate with text (marine invertebrates
-		swimming), a
-	</p>
-	<p>
-		Some <trademark /> text <m>math and stuff</m>. and
-		<ul>
-			<li>foo</li>
-			<li>bar</li>
-		</ul>
-		and more textsuch as HTML web pages. It might be additional information
-		that is hard to communicate with text (marine invertebrates swimming), a
-	</p>
-	<sage>
-		<output>fjdklsafjlkdjlkflk  fdjal f fjdlasjlf
+  <p>A video is a <br /> natural way to</p>
+  <p>
+    A video is a natural <br /> way to enhance a document when rendered in an
+    electronic format, such as HTML web pages.
+    It might be additional information that is hard to communicate with text
+    (marine invertebrates swimming), a
+  </p>
+  <p>
+    Some <trademark /> text <m>math and stuff</m>.
+    and
+    <ul>
+      <li>foo</li>
+      <li>bar</li>
+    </ul>
+     and more textsuch as HTML web pages.
+    It might be additional information that is hard to communicate with text
+    (marine invertebrates swimming), a
+  </p>
+  <sage>
+    <output>fjdklsafjlkdjlkflk  fdjal f fjdlasjlf
      jfdajldlsldk fjlkfajslfjllkadkf                baz</output>
-		<input>
+    <input>
                 A = matrix(4,5, srange(20)) <br />a really really really long line i think that it is long<br />
                  A.rref()
     </input>
-	</sage>
-	<p>
-		fun times
-		<ul>
-			<li>foo</li>
-			<li>bar</li>
-		</ul>with list
-	</p>
-	<p>
-		fun times
-		<ul>
-			<li>foo</li>
-			<li>bar</li>
-		</ul>
+  </sage>
+  <p>
+    fun times
+    <ul>
+      <li>foo</li>
+      <li>bar</li>
+    </ul>
+    with list
+  </p>
+  <p>
+    fun times
+    <ul>
+      <li>foo</li>
+      <li>bar</li>
+    </ul>
 
-		with list
-	</p>
+
+    with list
+  </p>
 </section>
 "
 `;
 
 exports[`bracketSameLine => true 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+
 <!DOCTYPE module PUBLIC \\"-//Puppy Crawl//DTD Check Configuration 1.3//EN\\"
-	\\"https://www.puppycrawl.com/dtds/configuration_1_3.dtd\\">
+  \\"https://www.puppycrawl.com/dtds/configuration_1_3.dtd\\">
 <?xml-model href=\\"project.rnc\\" type=\\"application/relax-ng-compact-syntax\\"?>
 <!-- foo -->
 <svg
-	xmlns=\\"http://www.w3.org/2000/svg\\"
-	xmlns:xlink=\\"http://www.w3.org/1999/xlink\\"
-	width=\\"200\\"
-	height=\\"100\\"
-	viewBox=\\"0 0 200 100\\"
+  xmlns=\\"http://www.w3.org/2000/svg\\"
+  xmlns:xlink=\\"http://www.w3.org/1999/xlink\\"
+  width=\\"200\\"
+  height=\\"100\\"
+  viewBox=\\"0 0 200 100\\"
 >
-	<title>Style inheritance and the use element</title>
-	<desc _attr=\\"attr\\">
+  <title>Style inheritance and the use element</title>
+
+  <desc _attr=\\"attr\\">
     &anp; &#12345;
     <![CDATA[
       foo
     ]]>
     bar
   </desc>
-	<?pagebreak?>
+  <?pagebreak?>
 
-	<style />
-	<style />
-	<style type=\\"text/css\\">
+  <style />
+  <style/>
+  <style type=\\"text/css\\">
 circle {
-	stroke-opacity: 0.7;
+  stroke-opacity: 0.7;
 }
 .special circle {
-	stroke: green;
+  stroke: green;
 }
 use {
-	stroke: purple;
-	fill: orange;
+  stroke: purple;
+  fill: orange;
 }
-	</style>
+  </style>
 
-	<yaml
-		myveryveryveryverylongattributename=\\"myveryveryveryverylongattributevalue\\"
-	>
-		- 1 - 2 - 3
-	</style>
+  <yaml
+    myveryveryveryverylongattributename=\\"myveryveryveryverylongattributevalue\\"
+  >- 1 - 2 - 3</style>
 
-	<!-- inner comment -->
+  <!-- inner comment -->
 
-	<?pagebreak?>
-	<g class=\\"special\\" style=\\"fill: blue\\">
-		<circle id=\\"c\\" cy=\\"50\\" cx=\\"50\\" r=\\"40\\" stroke-width=\\"20\\" />
-	</g>
-	<use xlink:href=\\"#c\\" x=\\"100\\" />
-	<ignored>
+  <?pagebreak?>
+  <g class=\\"special\\" style=\\"fill: blue\\">
+    <circle id=\\"c\\" cy=\\"50\\" cx=\\"50\\" r=\\"40\\" stroke-width=\\"20\\" />
+  </g>
+  <use xlink:href=\\"#c\\" x=\\"100\\" />
+  <ignored>
     <!-- prettier-ignore-start -->
       <   ignored   />
     <!-- prettier-ignore-end -->
   </ignored>
-	<p>
-		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed at est eget
-		enim consectetur accumsan. Aliquam pretium sodales ipsum quis dignissim.
-		Sed id sem vel diam luctus fringilla. Aliquam quis egestas magna.
-		Curabitur molestie lorem et odio porta, et molestie libero laoreet.
-		Morbi rhoncus sagittis cursus. Nullam vehicula pretium consequat.
-		Praesent porta ante at posuere sollicitudin. Nullam commodo tempor arcu,
-		at condimentum neque elementum ut.
-	</p>
-	<span>content</span>
+  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+  Sed at est eget enim consectetur accumsan.
+  Aliquam pretium sodales ipsum quis dignissim.
+  Sed id sem vel diam luctus fringilla.
+  Aliquam quis egestas magna.
+  Curabitur molestie lorem et odio porta, et molestie libero laoreet.
+  Morbi rhoncus sagittis cursus.
+  Nullam vehicula pretium consequat.
+  Praesent porta ante at posuere sollicitudin.
+  Nullam commodo tempor arcu, at condimentum neque elementum ut.</p>
+  <span>content</span>
 
-	<div>
-		even more
-		<content />
-	</div>
+  <div>
+    even more
+    <content />
+  </div>
 </svg>
 <!-- bar -->
 "
@@ -152,75 +157,76 @@ use {
 
 exports[`bracketSameLine => true, xmlSelfClosingSpace => false 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+
 <!DOCTYPE module PUBLIC \\"-//Puppy Crawl//DTD Check Configuration 1.3//EN\\"
-	\\"https://www.puppycrawl.com/dtds/configuration_1_3.dtd\\">
+  \\"https://www.puppycrawl.com/dtds/configuration_1_3.dtd\\">
 <?xml-model href=\\"project.rnc\\" type=\\"application/relax-ng-compact-syntax\\"?>
 <!-- foo -->
 <svg
-	xmlns=\\"http://www.w3.org/2000/svg\\"
-	xmlns:xlink=\\"http://www.w3.org/1999/xlink\\"
-	width=\\"200\\"
-	height=\\"100\\"
-	viewBox=\\"0 0 200 100\\"
+  xmlns=\\"http://www.w3.org/2000/svg\\"
+  xmlns:xlink=\\"http://www.w3.org/1999/xlink\\"
+  width=\\"200\\"
+  height=\\"100\\"
+  viewBox=\\"0 0 200 100\\"
 >
-	<title>Style inheritance and the use element</title>
-	<desc _attr=\\"attr\\">
+  <title>Style inheritance and the use element</title>
+
+  <desc _attr=\\"attr\\">
     &anp; &#12345;
     <![CDATA[
       foo
     ]]>
     bar
   </desc>
-	<?pagebreak?>
+  <?pagebreak?>
 
-	<style />
-	<style />
-	<style type=\\"text/css\\">
+  <style />
+  <style/>
+  <style type=\\"text/css\\">
 circle {
-	stroke-opacity: 0.7;
+  stroke-opacity: 0.7;
 }
 .special circle {
-	stroke: green;
+  stroke: green;
 }
 use {
-	stroke: purple;
-	fill: orange;
+  stroke: purple;
+  fill: orange;
 }
-	</style>
+  </style>
 
-	<yaml
-		myveryveryveryverylongattributename=\\"myveryveryveryverylongattributevalue\\"
-	>
-		- 1 - 2 - 3
-	</style>
+  <yaml
+    myveryveryveryverylongattributename=\\"myveryveryveryverylongattributevalue\\"
+  >- 1 - 2 - 3</style>
 
-	<!-- inner comment -->
+  <!-- inner comment -->
 
-	<?pagebreak?>
-	<g class=\\"special\\" style=\\"fill: blue\\">
-		<circle id=\\"c\\" cy=\\"50\\" cx=\\"50\\" r=\\"40\\" stroke-width=\\"20\\" />
-	</g>
-	<use xlink:href=\\"#c\\" x=\\"100\\" />
-	<ignored>
+  <?pagebreak?>
+  <g class=\\"special\\" style=\\"fill: blue\\">
+    <circle id=\\"c\\" cy=\\"50\\" cx=\\"50\\" r=\\"40\\" stroke-width=\\"20\\" />
+  </g>
+  <use xlink:href=\\"#c\\" x=\\"100\\" />
+  <ignored>
     <!-- prettier-ignore-start -->
       <   ignored   />
     <!-- prettier-ignore-end -->
   </ignored>
-	<p>
-		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed at est eget
-		enim consectetur accumsan. Aliquam pretium sodales ipsum quis dignissim.
-		Sed id sem vel diam luctus fringilla. Aliquam quis egestas magna.
-		Curabitur molestie lorem et odio porta, et molestie libero laoreet.
-		Morbi rhoncus sagittis cursus. Nullam vehicula pretium consequat.
-		Praesent porta ante at posuere sollicitudin. Nullam commodo tempor arcu,
-		at condimentum neque elementum ut.
-	</p>
-	<span>content</span>
+  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+  Sed at est eget enim consectetur accumsan.
+  Aliquam pretium sodales ipsum quis dignissim.
+  Sed id sem vel diam luctus fringilla.
+  Aliquam quis egestas magna.
+  Curabitur molestie lorem et odio porta, et molestie libero laoreet.
+  Morbi rhoncus sagittis cursus.
+  Nullam vehicula pretium consequat.
+  Praesent porta ante at posuere sollicitudin.
+  Nullam commodo tempor arcu, at condimentum neque elementum ut.</p>
+  <span>content</span>
 
-	<div>
-		even more
-		<content />
-	</div>
+  <div>
+    even more
+    <content />
+  </div>
 </svg>
 <!-- bar -->
 "
@@ -228,161 +234,368 @@ use {
 
 exports[`defaults 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+
 <!DOCTYPE module PUBLIC \\"-//Puppy Crawl//DTD Check Configuration 1.3//EN\\"
-	\\"https://www.puppycrawl.com/dtds/configuration_1_3.dtd\\">
+  \\"https://www.puppycrawl.com/dtds/configuration_1_3.dtd\\">
 <?xml-model href=\\"project.rnc\\" type=\\"application/relax-ng-compact-syntax\\"?>
 <!-- foo -->
 <svg
-	xmlns=\\"http://www.w3.org/2000/svg\\"
-	xmlns:xlink=\\"http://www.w3.org/1999/xlink\\"
-	width=\\"200\\"
-	height=\\"100\\"
-	viewBox=\\"0 0 200 100\\"
+  xmlns=\\"http://www.w3.org/2000/svg\\"
+  xmlns:xlink=\\"http://www.w3.org/1999/xlink\\"
+  width=\\"200\\"
+  height=\\"100\\"
+  viewBox=\\"0 0 200 100\\"
 >
-	<title>Style inheritance and the use element</title>
-	<desc _attr=\\"attr\\">
+  <title>Style inheritance and the use element</title>
+
+  <desc _attr=\\"attr\\">
     &anp; &#12345;
     <![CDATA[
       foo
     ]]>
     bar
   </desc>
-	<?pagebreak?>
+  <?pagebreak?>
 
-	<style />
-	<style />
-	<style type=\\"text/css\\">
+  <style />
+  <style/>
+  <style type=\\"text/css\\">
 circle {
-	stroke-opacity: 0.7;
+  stroke-opacity: 0.7;
 }
 .special circle {
-	stroke: green;
+  stroke: green;
 }
 use {
-	stroke: purple;
-	fill: orange;
+  stroke: purple;
+  fill: orange;
 }
-	</style>
+  </style>
 
-	<yaml
-		myveryveryveryverylongattributename=\\"myveryveryveryverylongattributevalue\\"
-	>
-		- 1 - 2 - 3
-	</style>
+  <yaml
+    myveryveryveryverylongattributename=\\"myveryveryveryverylongattributevalue\\"
+  >- 1 - 2 - 3</style>
 
-	<!-- inner comment -->
+  <!-- inner comment -->
 
-	<?pagebreak?>
-	<g class=\\"special\\" style=\\"fill: blue\\">
-		<circle id=\\"c\\" cy=\\"50\\" cx=\\"50\\" r=\\"40\\" stroke-width=\\"20\\" />
-	</g>
-	<use xlink:href=\\"#c\\" x=\\"100\\" />
-	<ignored>
+  <?pagebreak?>
+  <g class=\\"special\\" style=\\"fill: blue\\">
+    <circle id=\\"c\\" cy=\\"50\\" cx=\\"50\\" r=\\"40\\" stroke-width=\\"20\\" />
+  </g>
+  <use xlink:href=\\"#c\\" x=\\"100\\" />
+  <ignored>
     <!-- prettier-ignore-start -->
       <   ignored   />
     <!-- prettier-ignore-end -->
   </ignored>
-	<p>
-		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed at est eget
-		enim consectetur accumsan. Aliquam pretium sodales ipsum quis dignissim.
-		Sed id sem vel diam luctus fringilla. Aliquam quis egestas magna.
-		Curabitur molestie lorem et odio porta, et molestie libero laoreet.
-		Morbi rhoncus sagittis cursus. Nullam vehicula pretium consequat.
-		Praesent porta ante at posuere sollicitudin. Nullam commodo tempor arcu,
-		at condimentum neque elementum ut.
-	</p>
-	<span>content</span>
+  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+  Sed at est eget enim consectetur accumsan.
+  Aliquam pretium sodales ipsum quis dignissim.
+  Sed id sem vel diam luctus fringilla.
+  Aliquam quis egestas magna.
+  Curabitur molestie lorem et odio porta, et molestie libero laoreet.
+  Morbi rhoncus sagittis cursus.
+  Nullam vehicula pretium consequat.
+  Praesent porta ante at posuere sollicitudin.
+  Nullam commodo tempor arcu, at condimentum neque elementum ut.</p>
+  <span>content</span>
 
-	<div>
-		even more
-		<content />
-	</div>
+  <div>
+    even more
+    <content />
+  </div>
 </svg>
 <!-- bar -->
 "
 `;
 
+exports[`example3 1`] = `
+"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+
+<section xml:id=\\"section1\\" label=\\"mylabel\\">
+  <title>My section</title>
+
+  <idx><h>Index entry</h></idx>
+  <idx><h>entries</h> <h>index</h></idx>
+  <idx><h>my example</h><see>example, my</see></idx>
+
+  <p>This <term>is</term> a shorter line.</p>
+
+  <p>
+    This is a paragraph with <alert>lots</alert> of <em>examples or such</em> of
+    <term>inline</term> and <m>\\\\sin(x)</m> math-like <c>expressions</c>.
+  </p>
+
+  <p>
+    We begin our study of algebraic structures by investigating sets associated
+    with single operations that satisfy certain reasonable axioms; that is, we
+    want to define an operation on a set in a way that will generalize such
+    familiar structures as the integers <m>{\\\\mathbb Z}</m> together with the
+    single operation of addition, or invertible <m>2 \\\\times 2</m> matrices
+    together with the single operation of matrix multiplication.
+    The integers and the <m>2 \\\\times 2</m> matrices, together with their
+    respective single operations, are examples of algebraic structures known as
+    groups.<fn>A test footnote, with no real content.</fn>
+  </p>
+  <p>
+    We have already seen that two integers <m>a</m> and <m>b</m> are equivalent
+    mod <m>n</m> if <m>n</m> divides <m>a - b</m>.
+    The integers mod <m>n</m> also partition <m>{\\\\mathbb Z}</m> into <m>n</m>
+    different equivalence classes; we will denote the set of these equivalence
+    classes by
+    <m>{\\\\mathbb Z}_n</m>. <notation>
+      <usage>
+        <m>\\\\mathbb Z_n</m>
+      </usage>
+      <description>the integers modulo <m>n</m></description>
+    </notation> Consider the integers modulo 12 and the corresponding partition
+    of the integers:<md>
+      <mrow>{[0]} &amp; = \\\\{ \\\\ldots, -12, 0, 12, 24, \\\\ldots \\\\}</mrow>
+      <mrow> {[1]} &amp; = \\\\{ \\\\ldots, -11, 1, 13, 25, \\\\ldots \\\\}</mrow>
+      <mrow> &amp; \\\\vdots</mrow>
+      <mrow> {[11]} &amp; = \\\\{ \\\\ldots, -1, 11, 23, 35, \\\\ldots \\\\}</mrow>
+    </md>.
+  </p>
+
+  <example xml:id=\\"example-groups-zn-arithmetic-laws\\">
+    <title>Modular Arithmetic</title>
+
+    <p>
+      Most, but not all, of the usual laws of arithmetic hold for addition and
+      multiplication in <m>{\\\\mathbb Z}_n</m>.
+      For instance, it is not necessarily true that there is a multiplicative
+      inverse.
+      Consider the multiplication table for <m>{\\\\mathbb Z}_8</m> in
+      <xref ref=\\"figure-z8-mult\\" />.
+      Notice that 2, 4, and 6 do not have multiplicative inverses; that is, for <m>n
+      = 2</m>, 4, or 6, there is no integer <m>k</m> such that
+      <m>k n \\\\equiv 1 \\\\pmod{ 8}</m>.
+    </p>
+
+    <figure xml:id=\\"figure-z8-mult\\">
+      <caption>Multiplication table for <m>{\\\\mathbb Z_8}</m></caption>
+      <p>
+        <me>\\\\begin{array}{c|cccccccc}
+                    <![CDATA[\\\\cdot & 0 & 1 & 2 & 3 & 4 & 5 & 6 & 7 \\\\\\\\
+                    \\\\hline
+                    0       & 0 & 0 & 0 & 0 & 0 & 0 & 0 & 0 \\\\\\\\
+                    1       & 0 & 1 & 2 & 3 & 4 & 5 & 6 & 7 \\\\\\\\
+                    2       & 0 & 2 & 4 & 6 & 0 & 2 & 4 & 6 \\\\\\\\
+                    3       & 0 & 3 & 6 & 1 & 4 & 7 & 2 & 5 \\\\\\\\
+                    4       & 0 & 4 & 0 & 4 & 0 & 4 & 0 & 4 \\\\\\\\
+                    5       & 0 & 5 & 2 & 7 & 4 & 1 & 6 & 3 \\\\\\\\
+                    6       & 0 & 6 & 4 & 2 & 0 & 6 & 4 & 2 \\\\\\\\
+                    7       & 0 & 7 & 6 & 5 & 4 & 3 & 2 & 1 ]]>
+                    \\\\end{array}</me>
+      </p>
+    </figure>
+  </example>
+
+  <p>
+    This is a paragraph with <alert>lots and lots</alert> of <em>examples</em> of
+    <term>inline</term> and <m>\\\\sin(x)</m> math-like <c>expressions</c>.
+  </p>
+
+  <p>
+    Some display math: <me>\\\\int_1^2 f(x) \\\\, dx</me>.
+    How does that look?
+  </p>
+
+  <proposition xml:id=\\"proposition-zn-equiv-classes\\">
+    <statement>
+      <p>
+        Let <m>{\\\\mathbb Z}_n</m> be the set of equivalence classes of the
+        integers mod <m>n</m> and <m>a, b, c \\\\in {\\\\mathbb Z}_n</m>.
+        <ol>
+          <li>
+            <p>
+              Addition and multiplication are commutative:<md>
+                <mrow> a + b  &amp; \\\\equiv  b + a \\\\pmod{ n}</mrow>
+                <mrow> a  b   &amp; \\\\equiv  b  a \\\\pmod{ n}. </mrow>
+              </md>
+            </p>
+          </li>
+
+          <li>
+            <p>
+              Addition and multiplication are associative:<md>
+                <mrow> (a + b) + c  &amp; \\\\equiv  a + (b + c)\\\\pmod{ n}</mrow>
+                <mrow> (a  b)  c    &amp; \\\\equiv  a   (b  c) \\\\pmod{ n}</mrow>
+              </md>.
+            </p>
+          </li>
+
+          <li>
+            <p>
+              There are both additive and multiplicative identities:<md>
+                <mrow> a + 0  &amp; \\\\equiv  a \\\\pmod{ n}</mrow>
+                <mrow> a \\\\cdot  1  &amp; \\\\equiv  a \\\\pmod{ n}</mrow>
+              </md>.
+            </p>
+          </li>
+
+          <li>
+            <p>
+              Multiplication distributes over addition:<md>
+                <mrow>a (b + c) \\\\equiv a b + a c \\\\pmod{ n}</mrow>
+              </md>.
+            </p>
+          </li>
+
+          <li>
+            <p>
+              For every integer <m>a</m> there is an additive inverse <m>-a</m>:<md>
+                <mrow>a + (-a) \\\\equiv 0 \\\\pmod{ n}</mrow>
+              </md>.
+            </p>
+          </li>
+
+          <li>
+            <p>
+              Let <m>a</m> be a nonzero integer.
+              Then <m>\\\\gcd(a,n) = 1</m> if and only if there exists a
+              multiplicative inverse <m>b</m> for <m>a \\\\pmod{n}</m>; that is, a
+              nonzero integer
+              <m>b</m> such that <me>a b \\\\equiv 1 \\\\pmod{ n}</me>.
+            </p>
+          </li>
+        </ol>
+
+      </p>
+    </statement>
+
+    <proof>
+      <p>We will prove (1) and (6) and leave the remaining properties to be
+      proven in the exercises.</p>
+
+      <p>
+        (1) Addition and multiplication <latex /> are commutative modulo <m>n</m>
+        since the remainder of <m>a + b</m> divided by <m>n</m> is the same as
+        the remainder of <m>b + a</m> divided by <m>n</m>.
+      </p>
+
+      <p>
+        (6) Suppose that <m>\\\\gcd(a, n) = 1</m>.
+        Then there exist integers <m>r</m> and <m>s</m> such that
+        <m>ar + ns = 1</m>.
+        Since <m>ns = 1 - ar</m>, it must be the case that
+        <m>ar \\\\equiv 1 \\\\pmod{n}</m>.
+        Letting <m>b</m> be the equivalence class of <m>r</m>,
+        <m>a b \\\\equiv 1\\\\pmod{n}</m>.
+      </p>
+
+      <p>
+        Conversely, suppose that there exists an integer <m>b</m> such that <m>ab
+        \\\\equiv 1 \\\\pmod{ n}</m>.
+        Then <m>n</m> divides <m>ab -1</m>, so there is an integer <m>k</m> such
+        that <m>ab - nk = 1</m>.
+        Let <m>d = \\\\gcd(a,n)</m>.
+        Since <m>d</m> divides <m>ab - nk</m>, <m>d</m>
+        must also divide 1; hence, <m>d = 1</m>.
+      </p>
+    </proof>
+  </proposition>
+</section>
+"
+`;
+
+exports[`new 1`] = `
+"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+
+<section xml:id=\\"section1\\" label=\\"mylabel\\">
+  <title>My section about <pretext /></title>
+
+
+  <p>
+    short <me>\\\\sin(x) + 2</me>, paragraph?
+    Another sentence.
+  </p>
+</section>
+"
+`;
+
 exports[`singleAttributePerLine => true 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+
 <!DOCTYPE module PUBLIC \\"-//Puppy Crawl//DTD Check Configuration 1.3//EN\\"
-	\\"https://www.puppycrawl.com/dtds/configuration_1_3.dtd\\">
+  \\"https://www.puppycrawl.com/dtds/configuration_1_3.dtd\\">
 <?xml-model href=\\"project.rnc\\" type=\\"application/relax-ng-compact-syntax\\"?>
 <!-- foo -->
 <svg
-	xmlns=\\"http://www.w3.org/2000/svg\\"
-	xmlns:xlink=\\"http://www.w3.org/1999/xlink\\"
-	width=\\"200\\"
-	height=\\"100\\"
-	viewBox=\\"0 0 200 100\\"
+  xmlns=\\"http://www.w3.org/2000/svg\\"
+  xmlns:xlink=\\"http://www.w3.org/1999/xlink\\"
+  width=\\"200\\"
+  height=\\"100\\"
+  viewBox=\\"0 0 200 100\\"
 >
-	<title>Style inheritance and the use element</title>
-	<desc _attr=\\"attr\\">
+  <title>Style inheritance and the use element</title>
+
+  <desc _attr=\\"attr\\">
     &anp; &#12345;
     <![CDATA[
       foo
     ]]>
     bar
   </desc>
-	<?pagebreak?>
+  <?pagebreak?>
 
-	<style />
-	<style />
-	<style type=\\"text/css\\">
+  <style />
+  <style/>
+  <style type=\\"text/css\\">
 circle {
-	stroke-opacity: 0.7;
+  stroke-opacity: 0.7;
 }
 .special circle {
-	stroke: green;
+  stroke: green;
 }
 use {
-	stroke: purple;
-	fill: orange;
+  stroke: purple;
+  fill: orange;
 }
-	</style>
+  </style>
 
-	<yaml
-		myveryveryveryverylongattributename=\\"myveryveryveryverylongattributevalue\\"
-	>
-		- 1 - 2 - 3
-	</style>
+  <yaml
+    myveryveryveryverylongattributename=\\"myveryveryveryverylongattributevalue\\"
+  >- 1 - 2 - 3</style>
 
-	<!-- inner comment -->
+  <!-- inner comment -->
 
-	<?pagebreak?>
-	<g
-		class=\\"special\\"
-		style=\\"fill: blue\\"
-	>
-		<circle
-			id=\\"c\\"
-			cy=\\"50\\"
-			cx=\\"50\\"
-			r=\\"40\\"
-			stroke-width=\\"20\\" />
-	</g>
-	<use
-		xlink:href=\\"#c\\"
-		x=\\"100\\" />
-	<ignored>
+  <?pagebreak?>
+  <g
+    class=\\"special\\"
+    style=\\"fill: blue\\"
+  >
+    <circle
+      id=\\"c\\"
+      cy=\\"50\\"
+      cx=\\"50\\"
+      r=\\"40\\"
+      stroke-width=\\"20\\" />
+  </g>
+  <use
+    xlink:href=\\"#c\\"
+    x=\\"100\\" />
+  <ignored>
     <!-- prettier-ignore-start -->
       <   ignored   />
     <!-- prettier-ignore-end -->
   </ignored>
-	<p>
-		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed at est eget
-		enim consectetur accumsan. Aliquam pretium sodales ipsum quis dignissim.
-		Sed id sem vel diam luctus fringilla. Aliquam quis egestas magna.
-		Curabitur molestie lorem et odio porta, et molestie libero laoreet.
-		Morbi rhoncus sagittis cursus. Nullam vehicula pretium consequat.
-		Praesent porta ante at posuere sollicitudin. Nullam commodo tempor arcu,
-		at condimentum neque elementum ut.
-	</p>
-	<span>content</span>
+  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+  Sed at est eget enim consectetur accumsan.
+  Aliquam pretium sodales ipsum quis dignissim.
+  Sed id sem vel diam luctus fringilla.
+  Aliquam quis egestas magna.
+  Curabitur molestie lorem et odio porta, et molestie libero laoreet.
+  Morbi rhoncus sagittis cursus.
+  Nullam vehicula pretium consequat.
+  Praesent porta ante at posuere sollicitudin.
+  Nullam commodo tempor arcu, at condimentum neque elementum ut.</p>
+  <span>content</span>
 
-	<div>
-		even more
-		<content />
-	</div>
+  <div>
+    even more
+    <content />
+  </div>
 </svg>
 <!-- bar -->
 "
@@ -390,75 +603,76 @@ use {
 
 exports[`xmlSelfClosingSpace => false 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+
 <!DOCTYPE module PUBLIC \\"-//Puppy Crawl//DTD Check Configuration 1.3//EN\\"
-	\\"https://www.puppycrawl.com/dtds/configuration_1_3.dtd\\">
+  \\"https://www.puppycrawl.com/dtds/configuration_1_3.dtd\\">
 <?xml-model href=\\"project.rnc\\" type=\\"application/relax-ng-compact-syntax\\"?>
 <!-- foo -->
 <svg
-	xmlns=\\"http://www.w3.org/2000/svg\\"
-	xmlns:xlink=\\"http://www.w3.org/1999/xlink\\"
-	width=\\"200\\"
-	height=\\"100\\"
-	viewBox=\\"0 0 200 100\\"
+  xmlns=\\"http://www.w3.org/2000/svg\\"
+  xmlns:xlink=\\"http://www.w3.org/1999/xlink\\"
+  width=\\"200\\"
+  height=\\"100\\"
+  viewBox=\\"0 0 200 100\\"
 >
-	<title>Style inheritance and the use element</title>
-	<desc _attr=\\"attr\\">
+  <title>Style inheritance and the use element</title>
+
+  <desc _attr=\\"attr\\">
     &anp; &#12345;
     <![CDATA[
       foo
     ]]>
     bar
   </desc>
-	<?pagebreak?>
+  <?pagebreak?>
 
-	<style />
-	<style />
-	<style type=\\"text/css\\">
+  <style />
+  <style/>
+  <style type=\\"text/css\\">
 circle {
-	stroke-opacity: 0.7;
+  stroke-opacity: 0.7;
 }
 .special circle {
-	stroke: green;
+  stroke: green;
 }
 use {
-	stroke: purple;
-	fill: orange;
+  stroke: purple;
+  fill: orange;
 }
-	</style>
+  </style>
 
-	<yaml
-		myveryveryveryverylongattributename=\\"myveryveryveryverylongattributevalue\\"
-	>
-		- 1 - 2 - 3
-	</style>
+  <yaml
+    myveryveryveryverylongattributename=\\"myveryveryveryverylongattributevalue\\"
+  >- 1 - 2 - 3</style>
 
-	<!-- inner comment -->
+  <!-- inner comment -->
 
-	<?pagebreak?>
-	<g class=\\"special\\" style=\\"fill: blue\\">
-		<circle id=\\"c\\" cy=\\"50\\" cx=\\"50\\" r=\\"40\\" stroke-width=\\"20\\" />
-	</g>
-	<use xlink:href=\\"#c\\" x=\\"100\\" />
-	<ignored>
+  <?pagebreak?>
+  <g class=\\"special\\" style=\\"fill: blue\\">
+    <circle id=\\"c\\" cy=\\"50\\" cx=\\"50\\" r=\\"40\\" stroke-width=\\"20\\" />
+  </g>
+  <use xlink:href=\\"#c\\" x=\\"100\\" />
+  <ignored>
     <!-- prettier-ignore-start -->
       <   ignored   />
     <!-- prettier-ignore-end -->
   </ignored>
-	<p>
-		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed at est eget
-		enim consectetur accumsan. Aliquam pretium sodales ipsum quis dignissim.
-		Sed id sem vel diam luctus fringilla. Aliquam quis egestas magna.
-		Curabitur molestie lorem et odio porta, et molestie libero laoreet.
-		Morbi rhoncus sagittis cursus. Nullam vehicula pretium consequat.
-		Praesent porta ante at posuere sollicitudin. Nullam commodo tempor arcu,
-		at condimentum neque elementum ut.
-	</p>
-	<span>content</span>
+  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+  Sed at est eget enim consectetur accumsan.
+  Aliquam pretium sodales ipsum quis dignissim.
+  Sed id sem vel diam luctus fringilla.
+  Aliquam quis egestas magna.
+  Curabitur molestie lorem et odio porta, et molestie libero laoreet.
+  Morbi rhoncus sagittis cursus.
+  Nullam vehicula pretium consequat.
+  Praesent porta ante at posuere sollicitudin.
+  Nullam commodo tempor arcu, at condimentum neque elementum ut.</p>
+  <span>content</span>
 
-	<div>
-		even more
-		<content />
-	</div>
+  <div>
+    even more
+    <content />
+  </div>
 </svg>
 <!-- bar -->
 "

--- a/test/example3.ptx
+++ b/test/example3.ptx
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+    <section xml:id="section1" label="mylabel">
+<title>My section</title>
+    <idx>
+        <h>Index entry</h>
+    </idx>
+    <idx><h>entries</h>
+    <h>index</h></idx><idx><h>my example</h><see>example, my</see></idx>
+
+    <p>This <term>is</term> a shorter line.</p>
+
+    <p>
+        This is a paragraph with <alert>lots</alert> of <em>examples or such</em> of <term>inline</term> and <m>\sin(x)</m> math-like <c>expressions</c>.
+    </p>
+
+        <p>We begin our study of algebraic structures by investigating sets associated with single operations that satisfy certain reasonable axioms; that is, we want to define an operation on a set in a way that will generalize such familiar structures as the integers <m>{\mathbb Z}</m> together with the single operation of  addition, or invertible <m>2 \times 2</m> matrices together with the single operation of matrix multiplication.  The integers and the <m>2 \times 2</m> matrices, together with their respective single operations, are examples of algebraic structures known as groups.<fn>A test footnote, with no real content.</fn></p>
+            <p>We have already seen that two integers <m>a</m> and <m>b</m> are equivalent mod <m>n</m> if <m>n</m> divides <m>a - b</m>.  The integers mod <m>n</m> also partition <m>{\mathbb Z}</m> into <m>n</m> different equivalence classes; we will denote the set of these equivalence classes by <m>{\mathbb Z}_n</m>. <notation><usage><m>\mathbb Z_n</m></usage><description>the integers modulo <m>n</m></description></notation> Consider the integers modulo 12 and the corresponding partition of the integers:<md>
+                <mrow>{[0]} &amp; = \{ \ldots, -12, 0, 12, 24, \ldots \}</mrow>
+                <mrow> {[1]} &amp; = \{ \ldots, -11, 1, 13, 25, \ldots \}</mrow>
+                <mrow> &amp; \vdots</mrow>
+                <mrow> {[11]} &amp; = \{ \ldots, -1, 11, 23, 35, \ldots \}</mrow>
+            </md>.</p>
+
+            <example xml:id="example-groups-zn-arithmetic-laws">
+    <title>Modular Arithmetic</title>
+                <p>Most, but not all, of the usual laws of arithmetic hold for addition and multiplication in <m>{\mathbb Z}_n
+                </m>.  For instance, it is not necessarily true that there is a multiplicative inverse.  Consider the multiplication table for <m>{\mathbb Z}_8</m> in <xref ref="figure-z8-mult" />.  Notice that 2, 4, and 6 do not have multiplicative inverses; that is, for <m>n = 2</m>, 4, or 6, there is no integer <m>k</m> such that <m>k n \equiv 1 \pmod{ 8}</m>.</p>
+
+                <figure xml:id="figure-z8-mult">
+                    <caption>Multiplication table for <m>{\mathbb Z_8}</m></caption>
+                    <p><me>\begin{array}{c|cccccccc}
+                    <![CDATA[\cdot & 0 & 1 & 2 & 3 & 4 & 5 & 6 & 7 \\
+                    \hline
+                    0       & 0 & 0 & 0 & 0 & 0 & 0 & 0 & 0 \\
+                    1       & 0 & 1 & 2 & 3 & 4 & 5 & 6 & 7 \\
+                    2       & 0 & 2 & 4 & 6 & 0 & 2 & 4 & 6 \\
+                    3       & 0 & 3 & 6 & 1 & 4 & 7 & 2 & 5 \\
+                    4       & 0 & 4 & 0 & 4 & 0 & 4 & 0 & 4 \\
+                    5       & 0 & 5 & 2 & 7 & 4 & 1 & 6 & 3 \\
+                    6       & 0 & 6 & 4 & 2 & 0 & 6 & 4 & 2 \\
+                    7       & 0 & 7 & 6 & 5 & 4 & 3 & 2 & 1 ]]>
+                    \end{array}</me></p>
+                </figure>
+            </example>
+
+    <p>
+            This is a paragraph with <alert>lots
+            and lots
+            </alert> of <em>examples</em> of <term>
+        inline</term> and 
+        <m>\sin(x)</m> 
+math-like <c>expressions</c>.
+    </p>
+
+    <p>Some display math: <me>\int_1^2 f(x) \, dx</me>.  How does that look?</p>
+
+
+           <proposition xml:id="proposition-zn-equiv-classes">
+                <statement>
+                    <p>Let <m>{\mathbb Z}_n</m> be the set of equivalence classes of the integers mod <m>n</m> and <m>a, b, c \in {\mathbb Z}_n</m>.<ol>
+                        <li>
+                            <p>Addition and multiplication are commutative:<md>
+                                <mrow> a + b  &amp; \equiv  b + a \pmod{ n}</mrow>
+                                <mrow> a  b   &amp; \equiv  b  a \pmod{ n}. </mrow>
+                            </md></p>
+                        </li>
+
+                        <li>
+                            <p>Addition and multiplication are associative:<md>
+                                <mrow> (a + b) + c  &amp; \equiv  a + (b + c)\pmod{ n}</mrow>
+                                <mrow> (a  b)  c    &amp; \equiv  a   (b  c) \pmod{ n}</mrow>
+                            </md>.</p>
+                        </li>
+
+                        <li>
+                            <p>There are both additive and multiplicative identities:<md>
+                                <mrow> a + 0  &amp; \equiv  a \pmod{ n}</mrow>
+                                <mrow> a \cdot  1  &amp; \equiv  a \pmod{ n}</mrow>
+                            </md>.</p>
+                        </li>
+
+                        <li>
+                            <p>Multiplication distributes over addition:<md>
+                                <mrow>a  (b  + c)  \equiv a  b + a  c  \pmod{ n}</mrow>
+                            </md>.</p>
+                        </li>
+
+                        <li>
+                            <p>For every integer <m>a</m> there is an additive inverse <m>-a</m>:<md>
+                                <mrow> a + (-a)  \equiv 0 \pmod{ n}</mrow>
+                            </md>.</p>
+                        </li>
+
+                        <li>
+                            <p>Let <m>a</m> be a nonzero integer.  Then <m>\gcd(a,n) = 1</m> if and only if there exists a multiplicative inverse <m>b</m> for <m>a \pmod{n}</m>; that is, a nonzero integer <m>b</m> such that <me> a  b  \equiv 1 \pmod{ n}</me>.</p>
+                        </li>
+                    </ol></p>
+                </statement>
+
+                <proof>
+                    <p>We will prove (1) and (6) and leave the remaining properties to be proven in the exercises.</p>
+
+                    <p>(1) Addition and multiplication <latex  /> are commutative modulo <m>n</m> since the remainder of <m>a + b</m> divided by <m>n</m> is the same as the remainder of <m>b + a</m> divided by <m>n</m>.</p>
+
+                    <p>(6) Suppose that <m>\gcd(a, n) = 1</m>.  Then there exist integers <m>r</m> and <m>s</m> such that <m>ar + ns = 1</m>.  Since <m>ns = 1 - ar</m>, it must be the case that <m>ar \equiv 1 \pmod{n}</m>.  Letting <m>b</m> be the equivalence class of <m>r</m>, <m>a b \equiv 1\pmod{n}</m>.</p>
+
+                    <p>Conversely, suppose that there exists an integer <m>b</m> such that <m>ab  \equiv 1 \pmod{ n}</m>.  Then <m>n</m> divides <m>ab -1</m>, so there is an integer <m>k</m> such that <m>ab - nk = 1</m>.  Let <m>d = \gcd(a,n)</m>.  Since <m>d</m> divides <m>ab - nk</m>, <m>d</m> must also divide 1; hence, <m>d = 1</m>.</p>
+                </proof>
+            </proposition>
+</section>

--- a/test/example4.ptx
+++ b/test/example4.ptx
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+    <section xml:id="section1" label="mylabel">
+<title>My section about <pretext/></title>
+
+<p>short 
+    <me>
+        \sin(x) + 2 
+    </me>, 
+    paragraph? Another sentence.</p>
+
+
+</section>

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -14,6 +14,14 @@ const example2 = fs.readFileSync(
     path.join(__dirname, "./example2.ptx"),
     "utf-8"
 );
+const example3 = fs.readFileSync(
+    path.join(__dirname, "./example3.ptx"),
+    "utf-8"
+);
+const example4 = fs.readFileSync(
+    path.join(__dirname, "./example4.ptx"),
+    "utf-8"
+);
 
 function format(content: string, opts: Partial<Options> = {}) {
     return prettier.format(content, {
@@ -72,3 +80,14 @@ test("singleAttributePerLine => true", () => {
 
     expect(formatted).toMatchSnapshot();
 });
+
+test("example3", () => {
+    const formatted = format(example3);
+    expect(formatted).toMatchSnapshot();
+});
+
+test("new", () => {
+    const formatted = format(example4);
+    expect(formatted).toMatchSnapshot();
+});
+


### PR DESCRIPTION
This is the first of what I suspect will be many tweaks to the prettier plugin so pretext-tools can use this as its formatter.  The two things this does are give a hardbreak at the end of sentences in paragraphs, and give a break *after* an element in the `BREAK_AROUND_ELEMENTS`.  

That said, it is possible that I have gotten some of this wrong.  I'm seeing a number of different approaches to tweak things, and still wrapping my head around the way prettier printers recurse through the Doc.

If this looks reasonable, it would be helpful to get this released so pretext-tools can use it, which will help identify other targets for improvement.